### PR TITLE
:lipsticks: Fix theme colors (except for yellow)

### DIFF
--- a/app/src/main/java/fr/publicissapient/planningpoker/data/CardData.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/data/CardData.kt
@@ -1,9 +1,8 @@
 package fr.publicissapient.planningpoker.data
 
-import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.font.FontWeight
 
 fun fibo0(spanStyle: SpanStyle) =
     with(AnnotatedString.Builder("En 1991, le taux de couverture du marché du téléphone mobile dans le monde était de ")) {

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/body/Body.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/body/Body.kt
@@ -22,7 +22,7 @@ fun BodyWithBlop(content: @Composable () -> Unit) {
         Image(
             modifier = Modifier.fillMaxHeight(.9f),
             asset = vectorResource(id = R.drawable.ic_blop),
-            colorFilter = ColorFilter.tint(MaterialTheme.colors.primaryVariant),
+            colorFilter = ColorFilter.tint(MaterialTheme.colors.secondaryVariant),
             contentScale = ContentScale.FillHeight
         )
         content()

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/card/CardBackSideContent.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/card/CardBackSideContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,7 +30,7 @@ fun CardBackSideContent(
             .clickable(onClick = onClick),
         shape = RoundedCornerShape(32.dp * ratio),
         elevation = 8.dp,
-        backgroundColor = Color.Black,
+        backgroundColor = MaterialTheme.colors.primary,
     ) {
         Image(vectorResource(id = R.drawable.ic_logo_pse))
     }

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/card/CardContent.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/card/CardContent.kt
@@ -42,7 +42,7 @@ fun CardContent(
         elevation = 8.dp
     ) {
         Surface(
-            color = MaterialTheme.colors.primary,
+            color = MaterialTheme.colors.secondary,
             border = BorderStroke(16.dp * ratio, color = Color.White),
             shape = RoundedCornerShape(24.dp * ratio)
         ) {
@@ -62,7 +62,8 @@ fun CardContent(
                         modifier = Modifier.padding(horizontal = 30.dp * ratio),
                         style = MaterialTheme.typography.body2.copy(
                             textAlign = TextAlign.Center,
-                            fontSize = MaterialTheme.typography.body2.fontSize * ratio
+                            fontSize = MaterialTheme.typography.body2.fontSize * ratio,
+                            color = MaterialTheme.colors.primary
                         )
                     )
                 }
@@ -86,13 +87,13 @@ private fun Count(cardName: String, modifier: Modifier = Modifier, ratio: Float 
         )
         Text(
             text = cardName.toUpperCase(Locale.ROOT),
-            color = MaterialTheme.colors.onSurface,
+            color = MaterialTheme.colors.onPrimary,
             style = style,
             modifier = modifier
         )
         Text(
             text = cardName.toUpperCase(Locale.ROOT),
-            color = MaterialTheme.colors.onSurface,
+            color = MaterialTheme.colors.onPrimary,
             style = style,
             modifier = modifier
         )
@@ -103,8 +104,8 @@ private fun Count(cardName: String, modifier: Modifier = Modifier, ratio: Float 
 fun CardContentPreview() {
     PlanningPokerTheme {
         val cards = CardRepository().allCards(
-            MaterialTheme.colors.primary,
             MaterialTheme.colors.secondary,
+            MaterialTheme.colors.onSecondary,
         )[CardSuitType.Fibonacci]
         cards?.let {
             CardContent(

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/fab/SpeedDialFloatingActionButton.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/fab/SpeedDialFloatingActionButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.Colors
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -53,7 +54,7 @@ private fun SpeedDialFloatingButtonContent(
             icon = {
                 Image(asset = vectorResource(id = R.drawable.ic_fab))
             },
-            backgroundColor = Color.Black,
+            backgroundColor = MaterialTheme.colors.primary,
             modifier = Modifier.constrainAs(fab) {
                 bottom.linkTo(parent.bottom)
             }
@@ -122,7 +123,7 @@ private fun FloatingSpeedDialColor(
             icon = {
                 Icon(asset = vectorResource(id = R.drawable.ic_fab_dial), tint = tint)
             },
-            backgroundColor = Color.Black,
+            backgroundColor = MaterialTheme.colors.primary,
             modifier = modifier.width(35.dp).height(35.dp)
         )
     }

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/screen/CardListScreen.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/screen/CardListScreen.kt
@@ -32,8 +32,8 @@ fun CardListScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Retour", textAlign = TextAlign.Center) },
-                backgroundColor = Color.Black,
-                contentColor = Color.White,
+                backgroundColor = MaterialTheme.colors.primary,
+                contentColor = MaterialTheme.colors.onPrimary,
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(vectorResource(id = R.drawable.ic_baseline_arrow_back))
@@ -44,8 +44,8 @@ fun CardListScreen(
         bodyContent = {
             BodyWithBlop {
                 val cards = CardRepository().allCards(
-                    MaterialTheme.colors.primary,
-                    MaterialTheme.colors.secondary
+                    MaterialTheme.colors.secondary,
+                    MaterialTheme.colors.onSecondary
                 )[cardSuitType]
                 cards?.let {
                     CardListContent(cards, navigateToCard)

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/screen/CardScreen.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/screen/CardScreen.kt
@@ -33,8 +33,8 @@ fun CardScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Retour", textAlign = TextAlign.Center) },
-                backgroundColor = Color.Black,
-                contentColor = Color.White,
+                backgroundColor = MaterialTheme.colors.primary,
+                contentColor = MaterialTheme.colors.onPrimary,
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(vectorResource(id = R.drawable.ic_baseline_arrow_back))
@@ -45,8 +45,8 @@ fun CardScreen(
         bodyContent = {
             BodyWithBlop {
                 val cards = CardRepository().allCards(
-                    MaterialTheme.colors.primary,
-                    MaterialTheme.colors.secondary
+                    MaterialTheme.colors.secondary,
+                    MaterialTheme.colors.onSecondary
                 )[cardSuit]
                 cards?.let {
                     it.find { card ->

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/screen/CardTypeScreen.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/screen/CardTypeScreen.kt
@@ -29,8 +29,8 @@ fun CardTypeScreen(
     topBar = {
         TopAppBar(
             title = { Text("Planning Poker", textAlign = TextAlign.Center) },
-            backgroundColor = Color.Black,
-            contentColor = Color.White
+            backgroundColor = MaterialTheme.colors.primary,
+            contentColor = MaterialTheme.colors.onPrimary,
         )
     },
     bodyContent = {

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/theme/Color.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/theme/Color.kt
@@ -10,7 +10,7 @@ val primaryBlueVariant = Color(0xFFB9DDF4)
 
 val primaryYellow = Color(0xFFFFE63B)
 val primaryYellowVariant = Color(0xFFFFFCEB)
-val secondaryYellow = Color(0xFFCEBA01)
+val onSecondaryYellow = Color(0xFFCEBA01)
 
 val primaryGreen = Color(0xFF00E6C3)
 val primaryGreenVariant = Color(0xFFCDE9F0)

--- a/app/src/main/java/fr/publicissapient/planningpoker/ui/theme/Theme.kt
+++ b/app/src/main/java/fr/publicissapient/planningpoker/ui/theme/Theme.kt
@@ -8,35 +8,35 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.ui.graphics.Color
 
 val RedThemeColors = lightColors(
-    primary = primaryRed,
-    primaryVariant = primaryRedVariant,
-    secondary = Color.White,
-    onSurface = Color.White,
-    onPrimary = Color.Black
+    primary = Color.Black,
+    secondary = primaryRed,
+    secondaryVariant = primaryRedVariant,
+    onPrimary = Color.White,
+    onSecondary = Color.White
 )
 
 val BlueThemeColors = lightColors(
-    primary = primaryBlue,
-    primaryVariant = primaryBlueVariant,
-    secondary = Color.White,
-    onSurface = Color.White,
-    onPrimary = Color.Black
+    primary = Color.Black,
+    secondary = primaryBlue,
+    secondaryVariant = primaryBlueVariant,
+    onPrimary = Color.White,
+    onSecondary = Color.White
 )
 
 val YellowThemeColors = lightColors(
-    primary = primaryYellow,
-    primaryVariant = primaryYellowVariant,
-    secondary = secondaryYellow,
-    onSurface = Color.Black,
-    onPrimary = Color.Black,
+    primary = Color.Black,
+    secondary = primaryYellow,
+    secondaryVariant = primaryYellowVariant,
+    onPrimary = Color.White,
+    onSecondary = onSecondaryYellow
 )
 
 val GreenThemeColors = lightColors(
-    primary = primaryGreen,
-    primaryVariant = primaryGreenVariant,
-    secondary = Color.White,
-    onSurface = Color.White,
-    onPrimary = Color.Black,
+    primary = Color.Black,
+    secondary = primaryGreen,
+    secondaryVariant = primaryGreenVariant,
+    onPrimary = Color.White,
+    onSecondary = Color.White
 )
 
 @Composable


### PR DESCRIPTION
![device-2020-11-13-173604](https://user-images.githubusercontent.com/1364907/99096638-cd264b00-25d6-11eb-9468-fba882b00729.png)

Well except for yellow card because on the design they have black digits comparing to other color sets (which have white digit...)

Any ideas how to improve this?